### PR TITLE
Fix bugs with array parameters

### DIFF
--- a/DependencyInjection/Compiler/SetTestClientPass.php
+++ b/DependencyInjection/Compiler/SetTestClientPass.php
@@ -10,7 +10,12 @@ class SetTestClientPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (null === $container->getParameter('liip_functional_test.query.max_query_count')) {
+        // "query.max_query_count" is an array, it is only accessible
+        // through "query" node and getting the "max_query_count" array
+        // key with PHP.
+        $query = $container->getParameter('liip_functional_test.query');
+
+        if (null === $query['max_query_count']) {
             $container->removeDefinition('liip_functional_test.query.count_client');
 
             return;

--- a/QueryCounter.php
+++ b/QueryCounter.php
@@ -14,9 +14,14 @@ class QueryCounter
     /** @var \Doctrine\Common\Annotations\AnnotationReader */
     private $annotationReader;
 
-    public function __construct($defaultMaxCount, Reader $annotationReader)
+    /**
+     * "query.max_query_count" is an array, it is only accessible
+     * through "query" node and getting the "max_query_count" array
+     * key with PHP.
+     */
+    public function __construct($query, Reader $annotationReader)
     {
-        $this->defaultMaxCount = $defaultMaxCount;
+        $this->defaultMaxCount = $query['max_query_count'];
         $this->annotationReader = $annotationReader;
     }
 

--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -4,16 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-
-        <parameter key="liip_functional_test.html5validation.ignores" type="collection" />
-
-        <parameter key="liip_functional_test.html5validation.ignores_extract" type="collection" />
-
-        <parameter key="liip_functional_test.query.max_query_count">null</parameter>
-
-    </parameters>
-
     <services>
         <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
@@ -30,7 +20,9 @@
         </service>
 
         <service id="liip_functional_test.query.counter" class="Liip\FunctionalTestBundle\QueryCounter">
-            <argument>%liip_functional_test.query.max_query_count%</argument>
+            <!-- "liip_functional_test.query" is an array, we can't access to
+                "liip_functional_test.query.max_query_count" directly -->
+            <argument>%liip_functional_test.query%</argument>
             <argument type="service" id="annotation_reader" />
         </service>
     </services>

--- a/Test/Html5WebTestCase.php
+++ b/Test/Html5WebTestCase.php
@@ -152,12 +152,17 @@ HTML;
         }
         $err_msg .= ":\n";
 
-        $ignores = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores');
+        // "html5validation.ignores" and,
+        // "html5validation.ignores_extract" are arrays,
+        // they are only accessible through "ignores" node and getting the
+        // array with PHP.
+        $html5validation = $this->getContainer()->getParameter('liip_functional_test.html5validation');
+        $ignores = $html5validation['ignores'];
         /*
          * unfortunately, the bamboo html5 validator.nu gives back an empty "message" about the error with brightcove object, but we have to ignore the error
          * if our local validator.nu instance is fixed, this stuff should go away
          */
-        $ignores_extract = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores_extract');
+        $ignores_extract = $html5validation['ignores_extract'];
 
         foreach ($res->messages as $row) {
             if ($row->type == 'error') {

--- a/Tests/App/Config/config.yml
+++ b/Tests/App/Config/config.yml
@@ -1,5 +1,19 @@
 framework:
+    secret:          secret
+    test: ~
     router: { resource: "%kernel.root_dir%/../routing.yml" }
+    form:            true
+    csrf_protection: true
+    templating:      { engines: ['twig'] }
+    session:
+        # handler_id set to null will use default session handler from php.ini
+        handler_id:  ~
+        storage_id: session.storage.filesystem
+        # https://groups.google.com/forum/#!topic/symfony2/IB-CpMgo5o0
+        name: MOCKSESSID
+    profiler:
+        enabled: true
+        collect: true
 
 # Define all the available parameters in this Bundle
 liip_functional_test:
@@ -7,7 +21,7 @@ liip_functional_test:
     command_verbosity: "very_verbose"
     command_decoration: false
     query:
-        max_query_count: 5
+        max_query_count: 1
     authentication:
         username: "foobar"
         password: "12341234"

--- a/Tests/App/bootstrap.php
+++ b/Tests/App/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Composer\Autoload\ClassLoader;
+
+/**
+ * @var ClassLoader
+ */
+$loader = require __DIR__.'/../../vendor/autoload.php';
+
+AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+
+return $loader;

--- a/Tests/DependencyInjection/ConfigurationConfigTest.php
+++ b/Tests/DependencyInjection/ConfigurationConfigTest.php
@@ -40,7 +40,7 @@ class ConfigurationConfigTest extends ConfigurationTest
             array('command_verbosity', 'very_verbose'),
             array('command_decoration', false),
             array('query', array(
-                'max_query_count' => 5,
+                'max_query_count' => 1,
             )),
             array('authentication', array(
                 'username' => 'foobar',

--- a/Tests/Test/WebTestCaseConfigTest.php
+++ b/Tests/Test/WebTestCaseConfigTest.php
@@ -11,6 +11,7 @@
 
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
+use Liip\FunctionalTestBundle\Annotations\QueryCount;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 /**
@@ -154,6 +155,8 @@ class WebTestCaseConfigTest extends WebTestCase
 
     /**
      * Log in as the user defined in the Data Fixtures.
+     *
+     * @QueryCount(1)
      */
     public function testAdminAuthenticationLoginAs()
     {

--- a/Tests/Test/WebTestCaseConfigTest.php
+++ b/Tests/Test/WebTestCaseConfigTest.php
@@ -153,7 +153,7 @@ class WebTestCaseConfigTest extends WebTestCase
     }
 
     /**
-     * Log in as the user defined in the Data Fixture.
+     * Log in as the user defined in the Data Fixtures.
      */
     public function testAdminAuthenticationLoginAs()
     {
@@ -201,5 +201,44 @@ class WebTestCaseConfigTest extends WebTestCase
             'Admin',
             $crawler->filter('h2')->text()
         );
+    }
+
+    /**
+     * Log in as the user defined in the Data Fixtures.
+     */
+    public function testUserAuthenticationLoginAs()
+    {
+        $fixtures = $this->loadFixtures(array(
+            'Liip\FunctionalTestBundle\DataFixtures\ORM\LoadUserData',
+        ));
+
+        $this->assertInstanceOf(
+            'Doctrine\Common\DataFixtures\Executor\AbstractExecutor',
+            $fixtures
+        );
+
+        $repository = $fixtures->getReferenceRepository();
+
+        // One query to log in the first user
+        $loginAs = $this->loginAs($repository->getReference('user'),
+            'secured_area');
+
+        $this->assertInstanceOf(
+            'Liip\FunctionalTestBundle\Tests\Test\WebTestCaseConfigTest',
+            $loginAs
+        );
+
+        $this->client = static::makeClient();
+
+        // One query to load the second user
+        $path = '/user/2';
+
+        // There will be 2 queries, in the config the limit is 1,
+        // an Exception will be thrown.
+        $this->setExpectedException(
+            'Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException'
+        );
+
+        $crawler = $this->client->request('GET', $path);
     }
 }

--- a/Tests/Test/WebTestCaseConfigTest.php
+++ b/Tests/Test/WebTestCaseConfigTest.php
@@ -155,8 +155,6 @@ class WebTestCaseConfigTest extends WebTestCase
 
     /**
      * Log in as the user defined in the Data Fixtures.
-     *
-     * @QueryCount(1)
      */
     public function testAdminAuthenticationLoginAs()
     {
@@ -237,6 +235,36 @@ class WebTestCaseConfigTest extends WebTestCase
         $path = '/user/2';
 
         // There will be 2 queries, in the config the limit is 1,
+        // an Exception will be thrown.
+        $this->setExpectedException(
+            'Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException'
+        );
+
+        $crawler = $this->client->request('GET', $path);
+    }
+
+    /**
+     * Expect an exception due to the annotation QueryCount.
+     *
+     * @QueryCount(0)
+     */
+    public function testAnnotationAndException()
+    {
+        $fixtures = $this->loadFixtures(array(
+            'Liip\FunctionalTestBundle\DataFixtures\ORM\LoadUserData',
+        ));
+
+        $this->assertInstanceOf(
+            'Doctrine\Common\DataFixtures\Executor\AbstractExecutor',
+            $fixtures
+        );
+
+        $this->client = static::makeClient();
+
+        // One query to load the second user
+        $path = '/user/1';
+
+        // There will be 1 query, in the annotation the limit is 1,
         // an Exception will be thrown.
         $this->setExpectedException(
             'Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException'

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -12,7 +12,6 @@
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
-use Liip\FunctionalTestBundle\Annotations\QueryCount;
 
 class WebTestCaseTest extends WebTestCase
 {
@@ -324,9 +323,6 @@ class WebTestCaseTest extends WebTestCase
         );
     }
 
-    /**
-     * @QueryCount(100)
-     */
     public function testUserWithFixtures()
     {
         $fixtures = $this->loadFixtures(array(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
+    bootstrap="Tests/App/bootstrap.php"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
Parameters with array nodes are not directly accessible,
the parent node must be declared in PHP before accessing the relevant array key
